### PR TITLE
Add sinon-qunit package

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ While in testing mode (i.e. either when visiting `/tests` or when running `ember
 test(".runCallback() should run the callback passed", function(assert) {
   var spy = sinon.spy();
   this.subject().runCallback(spy);
+
+  // Default Sinon messages:
+  sinon.assert.calledOnce(spy);
+  sinon.assert.calledWith(spy, 'foo');
+
+  // Custom messages:
   assert.ok(spy.calledOnce, "the callback should be called once");
   assert.ok(spy.calledWith('foo'), "the callback should be passed 'foo' as an argument");
 });

--- a/blueprints/ember-sinon/index.js
+++ b/blueprints/ember-sinon/index.js
@@ -8,6 +8,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('sinonjs');
+    return this.addBowerPackagesToProject(['sinonjs', 'sinon-qunit']);
   }
 };

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ module.exports = {
       app.import('bower_components/sinonjs/sinon.js', {
         type: 'test'
       });
+      app.import('bower_components/sinon-qunit/lib/sinon-qunit.js', {
+        type: 'test'
+      });
     }
   }
 };


### PR DESCRIPTION
Sinon provides a well rounded assertion API that by default throws exceptions. Sinon-qunit package is a plugin-ish to use sinon assertions but be plugged into QUnit test framework. With the two together you can get better and more descriptive assertions while working with QUnit.

Since Ember-CLI uses QUnit it would be fantastic if the sinon-qunit package was available.

http://sinonjs.org/qunit/