### PR TITLE
Add sinon-qunit package

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ import sinon from 'sinon';
 test(".runCallback() should run the callback passed", function(assert) {
   var spy = sinon.spy();
   this.subject().runCallback(spy);
+
+  // Default Sinon messages:
+  sinon.assert.calledOnce(spy);
+  sinon.assert.calledWith(spy, 'foo');
+
+  // Custom messages:
   assert.ok(spy.calledOnce, "the callback should be called once");
   assert.ok(spy.calledWith('foo'), "the callback should be passed 'foo' as an argument");
 });

--- a/vendor/ember-sinon/shim.js
+++ b/vendor/ember-sinon/shim.js
@@ -1,7 +1,38 @@
-/* globals sinon */
+/* globals sinon, QUnit, test */
 
 define('sinon', [], function() {
   "use strict";
+
+  if (QUnit) {
+    sinon.expectation.fail = sinon.assert.fail = function (msg) {
+      QUnit.ok(false, msg);
+    };
+
+    sinon.assert.pass = function (assertion) {
+      QUnit.ok(true, assertion);
+    };
+
+    sinon.config = {
+      injectIntoThis: true,
+      injectInto: null,
+      properties: ["spy", "stub", "mock", "clock", "sandbox"],
+      useFakeTimers: false,
+      useFakeServer: false
+    };
+
+    (function (global) {
+      var qTest = QUnit.test;
+
+      QUnit.test = global.test = function (testName, expected, callback, async) {
+        if (arguments.length === 2) {
+          callback = expected;
+          expected = null;
+        }
+
+        return qTest(testName, expected, sinon.test(callback), async);
+      };
+    }(this));
+  }
 
   return {
     'default': sinon


### PR DESCRIPTION
Sinon provides a well rounded assertion API that by default throws exceptions. Sinon-qunit package is a plugin-ish to use sinon assertions but be plugged into QUnit test framework. With the two together you can get better and more descriptive assertions while working with QUnit.

Since Ember-CLI uses QUnit it would be fantastic if the sinon-qunit package was available.

Because sinon-qunit requires QUnit to be loaded first (I hate globals) the only way to make that happen is to lazily load the module. Since the original sinon-qunit code was never intended for that it was better to use the AMD shim to manage it. The source was so small it seems an acceptable option to manually place the code into the shim.

1.  The code is pretty stable and is unlikely to have much churn.
2.  It is wrapped in a conditional so it won't be executed if the user chooses not to use QUnit in favor of another test framework.

I hope this works ok. It is the only way I could think of to manage the _order_ of dependences with F*&%ing globals. (One of many reasons I detest QUnit.) :persevere: