### PR TITLE
Check typeof QUnit

### DIFF
--- a/vendor/ember-sinon/shim.js
+++ b/vendor/ember-sinon/shim.js
@@ -3,7 +3,7 @@
 define('sinon', [], function() {
   "use strict";
 
-  if (QUnit) {
+  if (typeof QUnit !== 'undefined') {
     sinon.expectation.fail = sinon.assert.fail = function (msg) {
       QUnit.ok(false, msg);
     };


### PR DESCRIPTION
To not throw an error if you're not using it. Fixes #14.