### PR TITLE
remove acceptance-test proxy from app

### DIFF
--- a/app/acceptance-tests/sinon.js
+++ b/app/acceptance-tests/sinon.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-sinon/acceptance-tests/sinon';


### PR DESCRIPTION
It seems this file serves no useful purpose; I guess it got put here when I used the generator for an acceptance test. Its presence causes some extra cruft to show up in production builds, and removing it doesn't have any effect on this project's test suite.

closes #21 