### PR TITLE
remove qunit from bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "ember": "~2.3.1",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
-    "qunit": "~1.20.0"
+    "ember-qunit-notifications": "0.1.0"
   }
 }


### PR DESCRIPTION
The ember-cli-qunit npm package gives us qunit without needing to get it from bower.