### PR TITLE
Simplify "sinon" import code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,12 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
   name: 'ember-sinon',
-
-  options: {
-    nodeAssets: {
-      'sinon': {
-        import: [{ path: 'pkg/sinon.js', type: 'test' }]
-      }
-    }
-  },
 
   included: function(app) {
     this._super.included.apply(this, arguments);
@@ -19,6 +15,21 @@ module.exports = {
       app = app.app;
     }
 
+    app.import('vendor/sinon/sinon.js', { type: 'test' });
     app.import('vendor/shims/sinon.js', { type: 'test' });
+  },
+
+  treeForVendor: function(tree) {
+    var sinonPath = path.dirname(require.resolve('sinon/pkg/sinon'));
+    var sinonTree = new Funnel(sinonPath, {
+      files: ['sinon.js'],
+      destDir: '/sinon',
+    });
+
+    var trees = [tree, sinonTree];
+
+    return new MergeTrees(trees, {
+      annotation: 'ember-sinon: treeForVendor'
+    });
   }
 };

--- a/index.js
+++ b/index.js
@@ -14,11 +14,7 @@ module.exports = {
 
   included: function (app) {
     this._super.included.apply(this, arguments);
-    if (app.tests) {
-      app.import('vendor/ember-sinon/shim.js', {
-        type: 'test',
-        exports: { 'sinon': ['default'] }
-      });
-    }
+
+    app.import('vendor/shims/sinon.js', { type: 'test' });
   }
 };

--- a/index.js
+++ b/index.js
@@ -8,18 +8,23 @@ var MergeTrees = require('broccoli-merge-trees');
 module.exports = {
   name: 'ember-sinon',
 
-  included: function(app) {
+  included: function (app) {
     this._super.included.apply(this, arguments);
 
-    while (typeof app.import !== 'function' && app.app) {
-      app = app.app;
+    var importContext;
+    if (this.import) {
+      // support for ember-cli >= 2.7
+      importContext = this;
+    } else {
+      // addon support for ember-cli < 2.7
+      importContext = this._findHostForLegacyEmberCLI();
     }
 
-    app.import('vendor/sinon/sinon.js', { type: 'test' });
-    app.import('vendor/shims/sinon.js', { type: 'test' });
+    importContext.import('vendor/sinon/sinon.js', { type: 'test' });
+    importContext.import('vendor/shims/sinon.js', { type: 'test' });
   },
 
-  treeForVendor: function(tree) {
+  treeForVendor: function (tree) {
     var sinonPath = path.dirname(require.resolve('sinon/pkg/sinon'));
     var sinonTree = new Funnel(sinonPath, {
       files: ['sinon.js'],
@@ -31,5 +36,20 @@ module.exports = {
     return new MergeTrees(trees, {
       annotation: 'ember-sinon: treeForVendor'
     });
+  },
+
+  // included from https://git.io/v6F7n
+  // not needed for ember-cli > 2.7
+  _findHostForLegacyEmberCLI: function() {
+    var current = this;
+    var app;
+
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    do {
+      app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
+
+    return app;
   }
 };

--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ module.exports = {
     }
   },
 
-  included: function (app) {
+  included: function(app) {
     this._super.included.apply(this, arguments);
+
+    while (typeof app.import !== 'function' && app.app) {
+      app = app.app;
+    }
 
     app.import('vendor/shims/sinon.js', { type: 'test' });
   }

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     "sinon"
   ],
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^1.2.1",
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-node-assets": "^0.1.1",
     "sinon": "^1.17.6"
   },
   "ember-addon": {

--- a/vendor/ember-sinon/shim.js
+++ b/vendor/ember-sinon/shim.js
@@ -1,9 +1,0 @@
-/* globals define, sinon */
-
-define('sinon', [], function() {
-  "use strict";
-
-  return {
-    'default': sinon
-  };
-});

--- a/vendor/shims/sinon.js
+++ b/vendor/shims/sinon.js
@@ -1,0 +1,9 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+
+    return { 'default': self['sinon'] };
+  }
+
+  define('sinon', [], vendorModule);
+})();


### PR DESCRIPTION
This essentially replaces the `ember-cli-node-assets` dependency with a `treeForVendor()` hook implementation with just two simple Broccoli nodes.

/cc @rwjblue @elwayman02 